### PR TITLE
lib: Skip files unable to be read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,15 @@ fn get_dependencies(blob_paths: &[&PathBuf]) -> HashMap<String, Vec<String>> {
             .expect("Could not convert to string.")
             .to_owned();
 
-        let buffer = fs::read(&path).expect("Could not read path.");
+        let buffer;
+        match fs::read(&path) {
+            Ok(b) => buffer = b,
+            Err(_) => {
+                eprintln!("Warning: Could not read file: {}", path.display());
+                return;
+            },
+        }
+
         let obj = goblin::Object::parse(&buffer);
 
         if let Ok(Object::Elf(elf)) = obj {


### PR DESCRIPTION
* Instead of aborting everything, let's just skip the files that errors out
* Example:
Warning: Could not read file libdl_android.so, skipping...
Warning: Could not read file libm.so, skipping...
Warning: Could not read file libdl.so, skipping...
Warning: Could not read file libc.so, skipping...
-proper list afterwards-

Change-Id: I04fa06b7eec06ba965be8836c16f0f1da311955a